### PR TITLE
Fix link typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ Add `lib/mix/tasks/deploy.ex`
 
 ## Add Conform for configuration
 
-Add [Conform])https://github.com/bitwalker/conform) to `deps` in `mix.exs`:
+Add [Conform](https://github.com/bitwalker/conform) to `deps` in `mix.exs`:
 
 ```elixir
  {:conform, "~> 2.2"}


### PR DESCRIPTION
Thanks for creating this awesome repo!

While reading through I noticed a typo in the link to Conform.
