### PR TITLE
Fixup asdf post_tasks that were defined as pre_tasks

### DIFF
--- a/ansible/playbooks/setup-build.yml
+++ b/ansible/playbooks/setup-build.yml
@@ -63,7 +63,7 @@
   roles:
     - tools-other
     - asdf
-  pre_tasks:
+  post_tasks:
     - name: Set vars
       set_fact:
         asdf_nodejs_keyring: "/home/{{ elixir_release_deploy_user }}/.asdf/keyrings/nodejs"


### PR DESCRIPTION
Tasks within the asdf install `pre_tasks` have a dependency on `asdf`, which is not installed at the point. Moving the tasks to `post_tasks` fixes the problem.