### PR TITLE
fixup build-release.sh `mix deps.get`

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -27,10 +27,10 @@ asdf install
 echo "Updating Elixir libs"
 mix local.hex --force
 mix local.rebar --force
+mix deps.get --only "$MIX_ENV"
 
 echo "Updating node libraries"
 (cd assets && npm install && node node_modules/brunch/bin/brunch build)
 
 echo "Building release"
-mix deps.get --only "$MIX_ENV"
 mix do compile, phx.digest, release


### PR DESCRIPTION
`mix deps.get` is required before `npm install` otherwise the latter fails:
`npm ERR! Could not install from "../deps/phoenix" as it does not contain a package.json file.`
because `../deps/` doesn't exist.