### PR TITLE
use project name for postgres user

### DIFF
--- a/ansible/inventory/group_vars/db-servers/postgresql.yml
+++ b/ansible/inventory/group_vars/db-servers/postgresql.yml
@@ -20,8 +20,8 @@ postgresql_user_privileges:
 postgresql_default_auth_method: "md5"
 
 postgresql_pg_hba_default:
-  # Allow OS postgres user to manage databases without a password
-  - { type: local, database: all, user: "{{ elixir_release_name_code }}", address: "", method: "peer", comment: "" }
+  # Allow OS postgres user to manage databasepostgresql_admin_users without a password
+  - { type: local, database: all, user: "{{ postgresql_admin_user }}", address: "", method: "peer", comment: "" }
   # Same for other users, as long as OS user matches PG user
   # - { type: local, database: all, user: all, address: "", method: "peer", comment: '"local" is for Unix domain socket connections only' }
   - { type: local, database: all, user: all, address: "", method: "{{ postgresql_default_auth_method }}", comment: '"local" is for Unix domain socket connections only' }
@@ -31,3 +31,5 @@ postgresql_pg_hba_default:
   # - { type: host, database: replication, user: all, address: "127.0.0.1/32", method: "{{ postgresql_default_auth_method }}", comment: "" }
   # - { type: host, database: replication, user: all, address: "::1/128",      method: "{{ postgresql_default_auth_method }}", comment: "" }
   - { type: host, database: all, user: all, address: "::1/128",      method: "{{ postgresql_default_auth_method }}", comment: "IPv6 local connections:" }
+  # Application DB with designated user password access
+  - { type: local, database: "{{ elixir_release_name_code }}_prod", user: "{{ elixir_release_name_code }}", address: "", method: "md5", comment: "" }

--- a/ansible/inventory/group_vars/db-servers/postgresql.yml
+++ b/ansible/inventory/group_vars/db-servers/postgresql.yml
@@ -21,7 +21,7 @@ postgresql_default_auth_method: "md5"
 
 postgresql_pg_hba_default:
   # Allow OS postgres user to manage databases without a password
-  - { type: local, database: all, user: "{{ postgresql_admin_user }}", address: "", method: "peer", comment: "" }
+  - { type: local, database: all, user: "{{ elixir_release_name_code }}", address: "", method: "peer", comment: "" }
   # Same for other users, as long as OS user matches PG user
   # - { type: local, database: all, user: all, address: "", method: "peer", comment: '"local" is for Unix domain socket connections only' }
   - { type: local, database: all, user: all, address: "", method: "{{ postgresql_default_auth_method }}", comment: '"local" is for Unix domain socket connections only' }


### PR DESCRIPTION
Current setup, postgres user will default to `postgres`. This PR will use project name instead.